### PR TITLE
Bug Fix On Mobile Screens

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -231,6 +231,7 @@
         display: flex;
         width: 100%;
         max-width: 19.5rem;
+        /* max-width: calc(100vw - 1rem); */
         padding: 0 1rem;
         min-height: 2.75rem;
         justify-content: space-between;
@@ -268,6 +269,7 @@
         height: 32px;
         padding: 0;
         margin-left: 17.825rem;
+        /* margin-left: calc(100vw - 3rem); */
         background: url('$lib/assets/chevron.svg'), no-repeat;
         background-size: 2rem auto;
         position: absolute;
@@ -442,6 +444,7 @@
         max-width: 21rem;
         height: 12.375rem;
         flex-shrink: 0;
+        padding: 0;
 
         /* Style */
         border-radius: 1rem;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -445,6 +445,7 @@
         height: 12.375rem;
         flex-shrink: 0;
         padding: 0;
+        margin-bottom: 1rem;
 
         /* Style */
         border-radius: 1rem;


### PR DESCRIPTION
Input fields have a default padding value that needs to be reset, this only displays in mobile browsers (for whatever reason)

Tested in safari mobile with padding:0; value applied and fit perfect!